### PR TITLE
Retry transient admin data fetches

### DIFF
--- a/composables/useAdminFetch.ts
+++ b/composables/useAdminFetch.ts
@@ -1,0 +1,46 @@
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const getFetchStatusCode = (error: unknown) => {
+  const fetchError = error as { status?: number, statusCode?: number, response?: { status?: number } }
+  return fetchError.statusCode || fetchError.status || fetchError.response?.status
+}
+
+export const useAdminFetch = () => {
+  const fetchAdminData = async <T>(
+    url: string,
+    options: Parameters<typeof $fetch<T>>[1] = {},
+    maxAttempts = 3
+  ): Promise<T> => {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await $fetch<T>(url, {
+          ...options,
+          headers: {
+            ...(options as { headers?: Record<string, string> })?.headers,
+            'cache-control': 'no-cache'
+          }
+        })
+      } catch (error) {
+        lastError = error
+        const statusCode = getFetchStatusCode(error)
+        const shouldRetry = !statusCode || RETRYABLE_STATUS_CODES.has(statusCode)
+
+        if (!shouldRetry || attempt === maxAttempts) {
+          break
+        }
+
+        await wait(400 * attempt)
+      }
+    }
+
+    throw lastError
+  }
+
+  return {
+    fetchAdminData
+  }
+}

--- a/pages/admin/designs/[id]/edit.vue
+++ b/pages/admin/designs/[id]/edit.vue
@@ -464,6 +464,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const route = useRoute()
 const router = useRouter()
 const loading = ref(false)
@@ -539,7 +540,7 @@ onMounted(async () => {
 const fetchDesign = async () => {
   try {
     console.log('Fetching design with ID:', route.params.id)
-    const response = await $fetch(`/api/admin/designs/${route.params.id}`)
+    const response = await fetchAdminData(`/api/admin/designs/${route.params.id}`)
     console.log('Design API response:', response)
     
     if (response.data) {
@@ -575,7 +576,7 @@ const fetchDesign = async () => {
 
 const fetchGoogleFonts = async () => {
   try {
-    const response = await $fetch('/api/admin/google-fonts')
+    const response = await fetchAdminData('/api/admin/google-fonts')
     if (response.success) {
       availableFonts.value = response.data
     }

--- a/pages/admin/designs/index.vue
+++ b/pages/admin/designs/index.vue
@@ -111,6 +111,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const designs = ref([])
 const activeDropdown = ref(null)
 const pageLoading = ref(true)
@@ -138,7 +139,7 @@ onMounted(async () => {
 
 const fetchDesigns = async () => {
   try {
-    const response = await $fetch('/api/admin/designs')
+    const response = await fetchAdminData('/api/admin/designs')
     designs.value = response.data || []
   } catch (error) {
     console.error('Error fetching designs:', error)

--- a/pages/admin/designs/new.vue
+++ b/pages/admin/designs/new.vue
@@ -456,6 +456,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const router = useRouter()
 const loading = ref(false)
 const pageLoading = ref(true)
@@ -527,7 +528,7 @@ onMounted(async () => {
 
 const fetchGoogleFonts = async () => {
   try {
-    const response = await $fetch('/api/admin/google-fonts')
+    const response = await fetchAdminData('/api/admin/google-fonts')
     if (response.success) {
       availableFonts.value = response.data
     }

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -147,6 +147,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const stats = ref({
   designs: 0,
   portfolio: 0,
@@ -165,10 +166,10 @@ onMounted(async () => {
   try {
     // Fetch stats
     const [designsRes, portfolioRes, linksRes, siteInfoRes] = await Promise.all([
-      $fetch('/api/admin/designs'),
-      $fetch('/api/admin/portfolio'),
-      $fetch('/api/admin/links'),
-      $fetch('/api/admin/site-info')
+      fetchAdminData('/api/admin/designs'),
+      fetchAdminData('/api/admin/portfolio'),
+      fetchAdminData('/api/admin/links'),
+      fetchAdminData('/api/admin/site-info')
     ])
 
     stats.value = {

--- a/pages/admin/links/index.vue
+++ b/pages/admin/links/index.vue
@@ -139,6 +139,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const links = ref([])
 const showAddForm = ref(false)
 const editingLink = ref(null)
@@ -166,7 +167,7 @@ onMounted(async () => {
 
 const fetchLinks = async () => {
   try {
-    const response = await $fetch('/api/admin/links')
+    const response = await fetchAdminData('/api/admin/links')
     links.value = response.data || []
   } catch (error) {
     console.error('Error fetching links:', error)

--- a/pages/admin/pages/index.vue
+++ b/pages/admin/pages/index.vue
@@ -88,6 +88,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const loading = ref(false)
 const pageLoading = ref(true)
 const pageError = ref(null)
@@ -115,7 +116,7 @@ onMounted(async () => {
 
 const fetchPages = async () => {
   try {
-    const response = await $fetch('/api/admin/pages')
+    const response = await fetchAdminData('/api/admin/pages')
     if (response.data) {
       Object.assign(form, response.data)
     }

--- a/pages/admin/portfolio/[id]/edit.vue
+++ b/pages/admin/portfolio/[id]/edit.vue
@@ -167,6 +167,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const route = useRoute()
 const router = useRouter()
 const loading = ref(false)
@@ -203,7 +204,7 @@ onMounted(async () => {
 
 const fetchProject = async () => {
   try {
-    const response = await $fetch(`/api/admin/portfolio/${route.params.id}`)
+    const response = await fetchAdminData(`/api/admin/portfolio/${route.params.id}`)
     if (response.data) {
       Object.assign(form, {
         ...response.data,

--- a/pages/admin/portfolio/index.vue
+++ b/pages/admin/portfolio/index.vue
@@ -114,6 +114,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const portfolio = ref([])
 const deleting = ref(false)
 const pageLoading = ref(true)
@@ -134,7 +135,7 @@ onMounted(async () => {
 
 const fetchPortfolio = async () => {
   try {
-    const response = await $fetch('/api/admin/portfolio')
+    const response = await fetchAdminData('/api/admin/portfolio')
     portfolio.value = response.data || []
   } catch (error) {
     console.error('Error fetching portfolio:', error)

--- a/pages/admin/site-info/index.vue
+++ b/pages/admin/site-info/index.vue
@@ -188,6 +188,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const loading = ref(false)
 const pageLoading = ref(true)
 const pageError = ref(null)
@@ -228,7 +229,7 @@ onMounted(async () => {
 
 const fetchSiteInfo = async () => {
   try {
-    const response = await $fetch('/api/admin/site-info')
+    const response = await fetchAdminData('/api/admin/site-info')
     if (response.data) {
       Object.assign(form, response.data)
     }
@@ -240,7 +241,7 @@ const fetchSiteInfo = async () => {
 
 const fetchDesigns = async () => {
   try {
-    const response = await $fetch('/api/admin/designs')
+    const response = await fetchAdminData('/api/admin/designs')
     designs.value = response.data || []
   } catch (error) {
     console.error('Error fetching designs:', error)

--- a/pages/admin/videos/[id]/edit.vue
+++ b/pages/admin/videos/[id]/edit.vue
@@ -106,6 +106,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const route = useRoute()
 const router = useRouter()
 const loading = ref(false)
@@ -134,7 +135,7 @@ onMounted(async () => {
 
 const fetchVideo = async () => {
   try {
-    const response = await $fetch(`/api/admin/videos/${route.params.id}`)
+    const response = await fetchAdminData(`/api/admin/videos/${route.params.id}`)
     if (response.data) {
       Object.assign(form, {
         title: response.data.title || '',

--- a/pages/admin/videos/index.vue
+++ b/pages/admin/videos/index.vue
@@ -111,6 +111,7 @@ definePageMeta({
   middleware: 'admin-auth'
 })
 
+const { fetchAdminData } = useAdminFetch()
 const videos = ref([])
 const deleting = ref(false)
 const pageLoading = ref(true)
@@ -131,7 +132,7 @@ onMounted(async () => {
 
 const fetchVideos = async () => {
   try {
-    const response = await $fetch('/api/admin/videos')
+    const response = await fetchAdminData('/api/admin/videos')
     videos.value = response.data || []
   } catch (error) {
     console.error('Error fetching videos:', error)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared admin fetch helper that retries transient GET failures such as 500/502/503/504 responses
- Use the retry helper for initial admin page data loads across dashboard, lists, edit forms, and settings pages
- Keep create/update/delete requests on normal `$fetch` so mutations are not retried

## Testing
- `DATABASE_URL="postgresql://user:password@localhost:5432/db" npx prisma validate`
- `npm run build`

## Notes
- I checked live endpoints including `/api/admin/designs`, `/api/admin/portfolio`, `/api/admin/site-info`, `/api/admin/pages`, and `/api/admin/portfolio/8`; they returned 200 from this environment, so this follow-up hardens the UI against transient server/database failures.
- Build emits existing local warnings for missing Supabase URL/key and outdated Browserslist data.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-515ccc17-68a1-4bd9-b67f-677a56bdee3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-515ccc17-68a1-4bd9-b67f-677a56bdee3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

